### PR TITLE
Add optional permissive SELinux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The daemon part of MSD runs as the `system` user and with the `CAP_CHOWN` capabi
 
 When setting up mass storage devices, the daemon never opens files on its own. The app opens files itself and then sends the open file descriptor the daemon over a Unix socket. This way, even if a malicious client happened to be able to connect to the daemon, it can't expose files over mass storage devices that it didn't already have access to.
 
-The daemon relies on SELinux for access control. If it detects certain scenarios where SELinux is not configured correctly, it will reject connections from all clients to avoid opening a security hole.
+The daemon relies on SELinux for access control. If it detects certain scenarios where SELinux is not configured correctly, it will reject connections from all clients to avoid opening a security hole. If SELinux must be run in permissive mode, start the daemon with `--allow-permissive-selinux` to bypass this check.
 
 ## Advanced features
 

--- a/msd-tool/src/daemon.rs
+++ b/msd-tool/src/daemon.rs
@@ -65,10 +65,10 @@ pub fn socket_addr() -> SocketAddr {
     SocketAddr::from_abstract_name("msdd").expect("Invalid abstract socket name")
 }
 
-/// Check that SELinux is enabled, enforcing, and that the policy seems to be
-/// correct. This acts as a sanity check since we rely on SELinux for access
-/// control.
-fn check_selinux() -> Result<()> {
+/// Check that SELinux is enabled and that the policy seems to be correct.
+/// When `allow_permissive` is `false`, also verify that SELinux is enforcing.
+/// This acts as a sanity check since we rely on SELinux for access control.
+fn check_selinux(allow_permissive: bool) -> Result<()> {
     let path = Path::new(SELINUX_ENFORCE);
 
     let mut file = File::open(path)
@@ -79,7 +79,7 @@ fn check_selinux() -> Result<()> {
         .read_u8()
         .with_context(|| format!("Failed to read file: {path:?}"))?;
 
-    if value != b'1' {
+    if value != b'1' && !allow_permissive {
         bail!("Denying connection because SELinux is not enforcing");
     }
 
@@ -265,8 +265,8 @@ fn handle_request(request: &Request) -> Response {
     })
 }
 
-fn handle_client(mut stream: UnixStream) -> Result<()> {
-    check_selinux()?;
+fn handle_client(mut stream: UnixStream, allow_permissive: bool) -> Result<()> {
+    check_selinux(allow_permissive)?;
     negotiate_protocol(&mut stream)?;
 
     loop {
@@ -341,7 +341,7 @@ fn drop_privileges() -> Result<()> {
     Ok(())
 }
 
-pub fn subcommand_daemon(_cli: &DaemonCli) -> Result<()> {
+pub fn subcommand_daemon(cli: &DaemonCli) -> Result<()> {
     drop_privileges()?;
 
     let listener =
@@ -352,6 +352,7 @@ pub fn subcommand_daemon(_cli: &DaemonCli) -> Result<()> {
             let stream = stream.context("Failed to accept incoming connection")?;
             let ucred = rustix::net::sockopt::socket_peercred(&stream)
                 .context("Failed to get socket peer credentials")?;
+            let allow_permissive = cli.allow_permissive_selinux;
 
             scope.spawn(move || {
                 let _span = info_span!(
@@ -369,7 +370,7 @@ pub fn subcommand_daemon(_cli: &DaemonCli) -> Result<()> {
 
                 info!("Received connection");
 
-                if let Err(e) = handle_client(stream) {
+                if let Err(e) = handle_client(stream, allow_permissive) {
                     error!("Thread failed: {e:?}");
                 }
             });
@@ -383,4 +384,8 @@ pub fn subcommand_daemon(_cli: &DaemonCli) -> Result<()> {
 
 /// Run daemon.
 #[derive(Debug, Parser)]
-pub struct DaemonCli;
+pub struct DaemonCli {
+    /// Allow connections even when SELinux is not enforcing.
+    #[arg(long)]
+    pub allow_permissive_selinux: bool,
+}


### PR DESCRIPTION
## Summary
- allow `msd-tool` daemon to run when SELinux is not enforcing via `--allow-permissive-selinux`
- document the new option in README

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo check` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686c4de46378832a9b8834ab972507ba