### PR TITLE
ci: upload debug build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,9 @@ jobs:
       - name: Build and test
         # Debug build only since release builds require a signing key
         run: ./gradlew --no-daemon build zipDebug -x assembleRelease
+
+      - name: Upload debug build
+        uses: actions/upload-artifact@v4 # v4.3.1
+        with:
+          name: msd-debug
+          path: app/build/distributions/debug/*.zip


### PR DESCRIPTION
## Summary
- store debug build outputs from CI

## Testing
- `cargo test --workspace --all-targets` *(fails: failed to fetch dependencies)*
- `./gradlew --no-daemon tasks` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686d099a8f74832ab6ed83dcb8a9017b