### PR TITLE
Add optional permissive SELinux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The daemon part of MSD runs as the `system` user and with the `CAP_CHOWN` capabi
 
 When setting up mass storage devices, the daemon never opens files on its own. The app opens files itself and then sends the open file descriptor the daemon over a Unix socket. This way, even if a malicious client happened to be able to connect to the daemon, it can't expose files over mass storage devices that it didn't already have access to.
 
-The daemon relies on SELinux for access control. If it detects certain scenarios where SELinux is not configured correctly, it will reject connections from all clients to avoid opening a security hole.
+The daemon relies on SELinux for access control. If it detects certain scenarios where SELinux is not configured correctly, it will reject connections from all clients to avoid opening a security hole. If SELinux must be run in permissive mode, start the daemon with `--allow-permissive-selinux` to bypass this check.
 
 ## Advanced features
 


### PR DESCRIPTION
## Summary
- allow `msd-tool` daemon to run when SELinux is not enforcing via `--allow-permissive-selinux`
- document the new option in README
- skip policy sanity check when permissive SELinux is allowed

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo check` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686c4de46378832a9b8834ab972507ba